### PR TITLE
Load COC API key from Gradle/local.properties and use BuildConfig in App

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,19 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        val cocApiKeyFromGradle = providers.gradleProperty("COC_API_KEY").orElse("").get()
+        val cocApiKeyFromLocal = providers.fileContents(rootProject.layout.projectDirectory.file("local.properties"))
+            .asText
+            .map { text ->
+                java.util.Properties().apply { load(text.reader()) }
+                    .getProperty("COC_API_KEY", "")
+            }
+            .orElse("")
+            .get()
+        val cocApiKey = cocApiKeyFromGradle.ifBlank { cocApiKeyFromLocal }
+
+        buildConfigField("String", "COC_API_KEY", "\"$cocApiKey\"")
     }
 
     buildTypes {

--- a/app/src/main/java/com/example/freemanstats/App.kt
+++ b/app/src/main/java/com/example/freemanstats/App.kt
@@ -23,8 +23,12 @@ class App : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-        SecurePrefs.saveApiKey(this, "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiIsImtpZCI6IjI4YTMxOGY3LTAwMDAtYTFlYi03ZmExLTJjNzQzM2M2Y2NhNSJ9.eyJpc3MiOiJzdXBlcmNlbGwiLCJhdWQiOiJzdXBlcmNlbGw6Z2FtZWFwaSIsImp0aSI6IjRkMTM3ZGNjLTRhZjUtNDJmMy05MzEyLTgxYzUxYjU4OTkyNCIsImlhdCI6MTc1MjQ4MDg3Miwic3ViIjoiZGV2ZWxvcGVyLzBmOTZhY2JlLWQzNTYtNDI1OS1kY2E0LWU2MTY1YWJhOGZhNSIsInNjb3BlcyI6WyJjbGFzaCJdLCJsaW1pdHMiOlt7InRpZXIiOiJkZXZlbG9wZXIvc2lsdmVyIiwidHlwZSI6InRocm90dGxpbmcifSx7ImNpZHJzIjpbIjUuMzUuMzMuMTgxIl0sInR5cGUiOiJjbGllbnQifV19.YGoHEvDRwUgbG8oRhf68pXd-K6q_jeTRm6GrnH4i0mlUXq2NzHeky9nNFWSITruUG-p989_cQRXKmejmM-28kA")
-        Log.d("App", "API key saved: ${SecurePrefs.getApiKey(this) != null}")
+        if (BuildConfig.COC_API_KEY.isNotBlank()) {
+            SecurePrefs.saveApiKey(this, "Bearer ${BuildConfig.COC_API_KEY}")
+            Log.d("App", "API key saved from BuildConfig")
+        } else {
+            Log.w("App", "COC_API_KEY is empty. Network calls to Clash of Clans API will fail until it is configured")
+        }
 
         WarSyncScheduler.schedule(this)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Optional: set Clash of Clans API key for local development (without Bearer prefix).
+# You can also put this into local.properties as COC_API_KEY=...
+# COC_API_KEY=


### PR DESCRIPTION
### Motivation

- Avoid hardcoding the Clash of Clans API key in source and allow configuring it via Gradle property or `local.properties` for local/dev builds.
- Ensure the app saves the API key at runtime from a safe build-time value and warn when it's missing to prevent silent failures.

### Description

- Added logic in `app/build.gradle.kts` to read `COC_API_KEY` from a Gradle property or from `local.properties` and expose it as `BuildConfig.COC_API_KEY` via `buildConfigField`.
- Replaced the previous hardcoded API token in `App.kt` with runtime usage of `BuildConfig.COC_API_KEY`, saving it as `Bearer ${BuildConfig.COC_API_KEY}` when present and logging a warning when empty.
- Updated `gradle.properties` to include documentation about the optional `COC_API_KEY` entry for local development.

### Testing

- Ran a Gradle build with `./gradlew assembleDebug` to verify the project config and the generated `BuildConfig` field, and the build completed successfully.
- Ran unit tests with `./gradlew test`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e12a5af108331a55e65121d5accc5)